### PR TITLE
Rulenode holes

### DIFF
--- a/src/HerbGrammar.jl
+++ b/src/HerbGrammar.jl
@@ -48,6 +48,7 @@ export
     contains_returntype,
     nchildren,
     child_types,
+    get_domain,
     get_childtypes,
     nonterminals,
     iscomplete,

--- a/src/HerbGrammar.jl
+++ b/src/HerbGrammar.jl
@@ -27,7 +27,9 @@ export
 
     Constraint,
     ContextSensitiveGrammar,
+    AbstractRuleNode,
     RuleNode,
+    Hole,
 
     ProbabilisticCFG,
 

--- a/src/HerbGrammar.jl
+++ b/src/HerbGrammar.jl
@@ -5,8 +5,8 @@ using AbstractTrees
 using DataStructures # NodeRecycler
 using Serialization # grammar_io
 
-include("rulenode.jl")
 include("grammar_base.jl")
+include("rulenode.jl")
 include("rulenode_operators.jl")
 include("utils.jl")
 include("cfg/cfg.jl")

--- a/src/cfg/cfg.jl
+++ b/src/cfg/cfg.jl
@@ -9,6 +9,7 @@ mutable struct ContextFreeGrammar <: Grammar
 	isterminal::BitVector 							# whether rule i is terminal
 	iseval::BitVector     							# whether rule i is an eval rule
 	bytype::Dict{Symbol,Vector{Int}}   				# maps type to all rules of said type
+	domains::Dict{Symbol,BitVector}					# maps type to a domain bitvector
 	childtypes::Vector{Vector{Symbol}} 				# list of types of the children for each rule. Empty if terminal
 	log_probabilities::Union{Vector{Real}, Nothing} # list of probabilities for the rules if this is a probabilistic grammar
 end
@@ -41,7 +42,8 @@ function expr2cfgrammar(ex::Expr)::ContextFreeGrammar
 	is_terminal = [isterminal(rule, alltypes) for rule ∈ rules]
 	is_eval = [iseval(rule) for rule ∈ rules]
 	childtypes = [get_childtypes(rule, alltypes) for rule ∈ rules]
-	return ContextFreeGrammar(rules, types, is_terminal, is_eval, bytype, childtypes, nothing)
+	domains = Dict(type => BitArray(r ∈ bytype[type] for r ∈ 1:length(rules)) for type ∈ alltypes)
+	return ContextFreeGrammar(rules, types, is_terminal, is_eval, bytype, domains, childtypes, nothing)
 end
 
 """

--- a/src/cfg/probabilistic_cfg.jl
+++ b/src/cfg/probabilistic_cfg.jl
@@ -49,7 +49,8 @@ function expr2pcfgrammar(ex::Expr)::ContextFreeGrammar
 	is_terminal = [isterminal(rule, alltypes) for rule in rules]
 	is_eval = [iseval(rule) for rule in rules]
 	childtypes = [get_childtypes(rule, alltypes) for rule in rules]
-	return ContextFreeGrammar(rules, types, is_terminal, is_eval, bytype, childtypes, log_probabilities)
+	domains = Dict(type => BitArray(r ∈ bytype[type] for r ∈ 1:length(rules)) for type ∈ alltypes)
+	return ContextFreeGrammar(rules, types, is_terminal, is_eval, bytype, domains, childtypes, log_probabilities)
 end
 
 """

--- a/src/csg/context.jl
+++ b/src/csg/context.jl
@@ -3,12 +3,12 @@ Structure used to track the context.
 Contains the expression being modified and the path to the current node.
 """
 mutable struct GrammarContext
-	originalExpr::RuleNode    	# original expression being modified
-	nodeLocation::Vector{Int}   # path to he current node in the expression, 
-                                # 	a sequence of child indices for each parent
+	originalExpr::AbstractRuleNode	# original expression being modified
+	nodeLocation::Vector{Int}   	# path to he current node in the expression, 
+                                	# 	a sequence of child indices for each parent
 end
 
-GrammarContext(originalExpr::RuleNode) = GrammarContext(originalExpr, [])
+GrammarContext(originalExpr::AbstractRuleNode) = GrammarContext(originalExpr, [])
 
 """
 Adds a parent to the context.

--- a/src/csg/csg.jl
+++ b/src/csg/csg.jl
@@ -6,7 +6,7 @@ abstract type Constraint end
 
 """
 Structure representing context-sensitive grammar
-Extends ExprRules.Grammar with constraints
+Extends Grammar with constraints
 """
 struct ContextSensitiveGrammar <: Grammar
 	rules::Vector{Any}
@@ -14,6 +14,7 @@ struct ContextSensitiveGrammar <: Grammar
 	isterminal::BitVector
 	iseval::BitVector
 	bytype::Dict{Symbol, Vector{Int}}
+	domains::Dict{Symbol,BitVector}    				
 	childtypes::Vector{Vector{Symbol}}
 	log_probabilities::Union{Vector{Real}, Nothing}
 	constraints::Vector{Constraint}
@@ -58,6 +59,7 @@ function cfg2csg(g::ContextFreeGrammar)::ContextSensitiveGrammar
         g.isterminal, 
         g.iseval, 
         g.bytype, 
+		g.domains,
         g.childtypes, 
         g.log_probabilities, 
         []

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -50,13 +50,6 @@ function get_childtypes(rule::Any, types::AbstractVector{Symbol})
 end
 
 """
-Returns the domain for the hole of a certain type
-	TODO: Should this be stored/cached in the grammar?
-"""
-get_domain(g::Grammar, type::Symbol)::BitVector = BitArray(r ∈ g.bytype[type] for r ∈ g.rules)
-
-
-"""
 Represents all grammars.
 The library assumes that the grammar structs have at least the following attributes:
 rules::Vector{Any}    # list of RHS of rules (subexpressions)
@@ -105,6 +98,13 @@ return_type(grammar::Grammar, rule_index::Int) = grammar.types[rule_index]
 Returns the types of the children (nonterminals) of the production rule at rule_index.
 """
 child_types(grammar::Grammar, rule_index::Int) = grammar.childtypes[rule_index]
+
+
+"""
+Returns the domain for the hole of a certain type
+	TODO: Should this be stored/cached in the grammar?
+"""
+get_domain(g::Grammar, type::Symbol)::BitVector = BitArray(r ∈ g.bytype[type] for r ∈ 1:length(g.rules))
 
 
 """

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -1,17 +1,4 @@
 """
-	Contains base types from grammar and the related functions
-	The library assumes that the grammar structs have at least the following attributes:
-	rules::Vector{Any}    # list of RHS of rules (subexpressions)
-	types::Vector{Symbol} # list of LHS of rules (types, all symbols)
-	isterminal::BitVector # whether rule i is terminal
-	iseval::BitVector     # whether rule i is an eval rule
-	bytype::Dict{Symbol,Vector{Int}}   # maps type to all rules of said type
-	childtypes::Vector{Vector{Symbol}} # list of types of the children for each rule. Empty if terminal
-"""
-
-
-
-"""
 Returns true if the rule is terminal, ie does not contain any of the types in the provided vector.
 For example, :(x) is terminal, and :(1+1) is terminal, but :(Real + Real) is typically not.
 """
@@ -57,6 +44,7 @@ types::Vector{Symbol} # list of LHS of rules (types, all symbols)
 isterminal::BitVector # whether rule i is terminal
 iseval::BitVector     # whether rule i is an eval rule
 bytype::Dict{Symbol,Vector{Int}}   # maps type to all rules of said type
+domains::Dict{Symbol,BitVector}    # maps type to a domain bitvector
 childtypes::Vector{Vector{Symbol}} # list of types of the children for each rule. Empty if terminal
 probabilities::Union{Vector{Real}, Nothing} # List of probabilities for each rule. Nothing if grammar is non-probabilistic
 """
@@ -102,9 +90,8 @@ child_types(grammar::Grammar, rule_index::Int) = grammar.childtypes[rule_index]
 
 """
 Returns the domain for the hole of a certain type.
-	TODO: Should this be stored/cached in the grammar?
 """
-get_domain(g::Grammar, type::Symbol)::BitVector = BitArray(r ∈ g.bytype[type] for r ∈ 1:length(g.rules))
+get_domain(g::Grammar, type::Symbol)::BitVector = deepcopy(g.domains[type])
 
 """
 Returns the domain bitvector for a domain defined as rule index vector.

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -101,31 +101,20 @@ child_types(grammar::Grammar, rule_index::Int) = grammar.childtypes[rule_index]
 
 
 """
-Returns the domain for the hole of a certain type
+Returns the domain for the hole of a certain type.
 	TODO: Should this be stored/cached in the grammar?
 """
 get_domain(g::Grammar, type::Symbol)::BitVector = BitArray(r ∈ g.bytype[type] for r ∈ 1:length(g.rules))
 
+"""
+Returns the domain bitvector for a domain defined as rule index vector.
+"""
+get_domain(g::Grammar, rules::Vector{Int})::BitVector = BitArray(r ∈ rules for r ∈ 1:length(g.rules))
 
 """
 Returns true if the production rule at rule_index is terminal, i.e., does not contain any nonterminal symbols.
 """
 isterminal(grammar::Grammar, rule_index::Int) = grammar.isterminal[rule_index]
-
-
-"""
-Returns true if the expression given by the node is complete expression, i.e., all leaves are terminal symbols
-"""
-function iscomplete(grammar::Grammar, node::RuleNode) 
-	if isterminal(grammar, node)
-		return true
-	elseif isempty(node.children)
-		# if not terminal but has children
-		return false
-	else
-		return all([iscomplete(grammar, c) for c in node.children])
-	end
-end
 
 
 """
@@ -183,63 +172,10 @@ Returns the maximum arity (number of children) over all production rules in the 
 max_arity(grammar::Grammar) = maximum(length(cs) for cs in grammar.childtypes)
 
 
-"""
-Returns the return type in the production rule used by node.
-"""
-return_type(grammar::Grammar, node::RuleNode) = grammar.types[node.ind]
-
-
-"""
-Returns the list of child types in the production rule used by node.
-"""
-child_types(grammar::Grammar, node::RuleNode) = grammar.childtypes[node.ind]
-
-
-"""
-Returns true if the production rule used by node is terminal, i.e., does not contain any nonterminal symbols.
-"""
-isterminal(grammar::Grammar, node::RuleNode) = grammar.isterminal[node.ind]
-
-
-"""
-Returns the number of children in the production rule used by node.
-"""
-nchildren(grammar::Grammar, node::RuleNode) = length(child_types(grammar, node))
-
-"""
-Returns true if the rule used by the node represents a variable.
-"""
-isvariable(grammar::Grammar, node::RuleNode) = grammar.isterminal[node.ind] && grammar.rules[node.ind] isa Symbol
-
-isvariable(grammar::Grammar, ind::Int) = grammar.isterminal[ind] && grammar.rules[ind] isa Symbol
-
-"""
-Returns true if the tree rooted at node contains at least one node at depth less than maxdepth
-with the given return type.
-"""
-function contains_returntype(node::RuleNode, grammar::Grammar, sym::Symbol, maxdepth::Int=typemax(Int))
-    maxdepth < 1 && return false
-    if return_type(grammar, node) == sym
-        return true
-    end
-    for c in node.children
-        if contains_returntype(c, grammar, sym, maxdepth-1)
-            return true
-        end
-    end
-    return false
-end
-
-
 function Base.show(io::IO, grammar::Grammar)
 	for i in eachindex(grammar.rules)
 	    println(io, i, ": ", grammar.types[i], " = ", grammar.rules[i])
 	end
-end
-
-
-function Base.display(rulenode::RuleNode, grammar::Grammar)
-	return rulenode2expr(rulenode, grammar)
 end
 
 

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -50,6 +50,13 @@ function get_childtypes(rule::Any, types::AbstractVector{Symbol})
 end
 
 """
+Returns the domain for the hole of a certain type
+	TODO: Should this be stored/cached in the grammar?
+"""
+get_domain(g::Grammar, type::Symbol)::BitVector = BitArray(r ∈ g.bytype[type] for r ∈ g.rules)
+
+
+"""
 Represents all grammars.
 The library assumes that the grammar structs have at least the following attributes:
 rules::Vector{Any}    # list of RHS of rules (subexpressions)

--- a/src/grammar_io.jl
+++ b/src/grammar_io.jl
@@ -54,14 +54,14 @@ Writes a context-sensitive grammar to the files at `grammarpath` and `constraint
 The `grammarpath` file will contain a CFG definition, and the
 `constraintspath` file will contain the constraints of the CSG.
 """
-function store_csg(grammarpath::AbstractString, constraintspath::AbstractString, grammar::ContextSensitiveGrammar)
+function store_csg(grammarpath::AbstractString, constraintspath::AbstractString, g::ContextSensitiveGrammar)
     # Store grammar as CFG
-    store_cfg(grammarpath, ContextFreeGrammar(grammar.rules, grammar.types, 
-        grammar.isterminal, grammar.iseval, grammar.bytype, grammar.childtypes, grammar.log_probabilities))
+    store_cfg(grammarpath, ContextFreeGrammar(g.rules, g.types, 
+        g.isterminal, g.iseval, g.bytype, g.domains, g.childtypes, g.log_probabilities))
     
     # Store constraints separately
     open(constraintspath, write=true) do file
-        serialize(file, grammar.constraints)
+        serialize(file, g.constraints)
     end
 end
 
@@ -77,7 +77,7 @@ function read_csg(grammarpath::AbstractString, constraintspath::AbstractString):
     close(file)
 
     return ContextSensitiveGrammar(g.rules, g.types, g.isterminal, 
-        g.iseval, g.bytype, g.childtypes, g.log_probabilities, constraints)
+        g.iseval, g.bytype, g.domains, g.childtypes, g.log_probabilities, constraints)
 end
 
 """
@@ -92,7 +92,7 @@ function read_pcsg(grammarpath::AbstractString, constraintspath::AbstractString)
     close(file)
 
     return ContextSensitiveGrammar(g.rules, g.types, g.isterminal, 
-        g.iseval, g.bytype, g.childtypes, g.log_probabilities, constraints)
+        g.iseval, g.bytype, g.domains, g.childtypes, g.log_probabilities, constraints)
 end
 
 

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -18,11 +18,13 @@ mutable struct Hole <: AbstractRuleNode
 	domain::BitVector
 end
 
-RuleNode(ind::Int) = RuleNode(ind, nothing, RuleNode[])
+RuleNode(ind::Int) = RuleNode(ind, nothing, AbstractRuleNode[])
 RuleNode(ind::Int, children::Vector{AbstractRuleNode}) = RuleNode(ind, nothing, children)
 RuleNode(ind::Int, children::Vector{RuleNode}) = RuleNode(ind, nothing, children)
 RuleNode(ind::Int, children::Vector{Hole}) = RuleNode(ind, nothing, children)
-RuleNode(ind::Int, _val::Any) = RuleNode(ind, _val, RuleNode[])
+RuleNode(ind::Int, _val::Any) = RuleNode(ind, _val, AbstractRuleNode[])
+RuleNode(ind::Int, grammar::Grammar) = RuleNode(ind, nothing, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[ind]])
+RuleNode(ind::Int, _val::Any, grammar::Grammar) = RuleNode(ind, _val, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[ind]])
 
 include("recycler.jl")
 

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -19,7 +19,9 @@ mutable struct Hole <: AbstractRuleNode
 end
 
 RuleNode(ind::Int) = RuleNode(ind, nothing, RuleNode[])
+RuleNode(ind::Int, children::Vector{AbstractRuleNode}) = RuleNode(ind, nothing, children)
 RuleNode(ind::Int, children::Vector{RuleNode}) = RuleNode(ind, nothing, children)
+RuleNode(ind::Int, children::Vector{Hole}) = RuleNode(ind, nothing, children)
 RuleNode(ind::Int, _val::Any) = RuleNode(ind, _val, RuleNode[])
 
 include("recycler.jl")

--- a/src/rulenode.jl
+++ b/src/rulenode.jl
@@ -27,18 +27,14 @@ RuleNode(ind::Int, grammar::Grammar) = RuleNode(ind, nothing, [Hole(get_domain(g
 RuleNode(ind::Int, _val::Any, grammar::Grammar) = RuleNode(ind, _val, [Hole(get_domain(grammar, type)) for type ∈ grammar.childtypes[ind]])
 
 include("recycler.jl")
-
-function Base.:(==)(A::AbstractRuleNode, B::AbstractRuleNode)
-	# Holes
-	(A isa Hole && B isa Hole) && (A.domain == B.domain) ||
-	# RuleNodes
-	(A isa RuleNode && B isa RuleNode) && 
-	(A.ind == B.ind) &&
-	(A._val == B._val) && 
-	(length(A.children) == length(B.children)) && #required because zip doesn't check lengths
-	all(isequal(a,b) for (a,b) in zip(A.children, B.children))
-end
     
+Base.:(==)(::RuleNode, ::Hole) = false
+Base.:(==)(::Hole, ::RuleNode) = false
+Base.:(==)(A::RuleNode, B::RuleNode) = 
+	(A.ind == B.ind) && 
+	length(A.children) == length(B.children) && #required because zip doesn't check lengths
+	all(isequal(a, b) for (a, b) ∈ zip(A.children, B.children))
+Base.:(==)(A::Hole, B::Hole) = A.domain == B.domain
 
 function Base.hash(node::RuleNode, h::UInt=zero(UInt))
 	retval = hash(node.ind, h)

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -19,7 +19,9 @@ function rulesoftype(node::RuleNode, ruleset::Set{Int})
 	end
 end
 
+rulesoftype(::Hole, ::Set{Int}) = Set()
 rulesoftype(node::RuleNode, grammar::Grammar, ruletype::Symbol) = rulesoftype(node, Set(grammar[ruletype]))
+rulesoftype(::Hole, ::Grammar, ::Symbol) = Set()
 
 
 """
@@ -46,9 +48,10 @@ function rulesoftype(node::RuleNode, ruleset::Set{Int}, ignoreNode::RuleNode)
 		return retval
 	end
 end
+rulesoftype(::Hole, ::Set{Int}, ::RuleNode) = Set()
 
 rulesoftype(node::RuleNode, grammar::Grammar, ruletype::Symbol, ignoreNode::RuleNode) = rulesoftype(node, Set(grammar[ruletype]), ignoreNode)
-
+rulesoftype(::Hole, ::Grammar, ::Symbol, ::RuleNode) = Set()
 
 """
 Replace a node in expr, specified by path, with new_expr.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -133,5 +133,5 @@ end
 Returns true if the node has children
 """
 has_children(rule::RuleNode) = !isempty(rule.children)
-
+has_children(::Hole) = false
 


### PR DESCRIPTION
Adds a separate Hole constructor that can be used inside RuleNode trees. 
This replaces the old functionality where there would be an implicit hole of the number of children in the RuleNode is lower than the number of children in the associated rule.

Required for 

- https://github.com/Herb-AI/HerbSearch.jl/pull/22

This grammar is still compatible with older versions of search that do not make use of explicit holes.

Closes #12 