### PR TITLE
Extra helper functions

### DIFF
--- a/src/HerbGrammar.jl
+++ b/src/HerbGrammar.jl
@@ -46,6 +46,7 @@ export
     isvariable,
     return_type,
     contains_returntype,
+    contains_hole
     nchildren,
     child_types,
     get_domain,

--- a/src/HerbGrammar.jl
+++ b/src/HerbGrammar.jl
@@ -46,7 +46,7 @@ export
     isvariable,
     return_type,
     contains_returntype,
-    contains_hole
+    contains_hole,
     nchildren,
     child_types,
     get_domain,

--- a/src/HerbGrammar.jl
+++ b/src/HerbGrammar.jl
@@ -76,6 +76,7 @@ export
     get_rulesequence,
     rulesoftype,
     rulesonleft,
+    get_node_at_location,
     rulenode2expr,
     rulenode_log_probability,
 

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -140,6 +140,25 @@ rulesonleft(::Hole, ::Vector{Int}) = Set{Int}()
 
 
 """
+Retrieves a rulenode at the original location by reference. 
+"""
+function get_node_at_location(root::RuleNode, location::Vector{Int})
+    if location == []
+        return root
+    else
+        return get_node_at_location(root.children[location[1]], location[2:end])
+    end
+end
+
+function get_node_at_location(root::Hole, location::Vector{Int})
+    if location == []
+        return root
+    end
+    return nothing
+end
+
+
+"""
 Converts a rulenode into a julia expression. 
 The returned expression can be evaluated with Julia semantics using eval().
 """

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -264,7 +264,7 @@ end
 """
 Checks if a rulenode tree contains a hole.
 """
-contains_hole(rn::RuleNode) = any(containsHole(c) for c ∈ rn.children)
+contains_hole(rn::RuleNode) = any(contains_hole(c) for c ∈ rn.children)
 contains_hole(hole::Hole) = true
 
 

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -261,6 +261,13 @@ function contains_returntype(node::RuleNode, grammar::Grammar, sym::Symbol, maxd
 end
 
 
+"""
+Checks if a rulenode tree contains a hole.
+"""
+contains_hole(rn::RuleNode) = any(containsHole(c) for c ∈ rn.children)
+contains_hole(hole::Hole) = true
+
+
 function Base.display(rulenode::RuleNode, grammar::Grammar)
 	root = rulenode2expr(rulenode, grammar)
 	if isa(root, Expr)


### PR DESCRIPTION
Adds two helper functions:

- `contains_hole` checks if a RuleNode tree contains a Hole, i.e. whether it is partial.
- `get_node_at_location` takes a RuleNode tree and a path to a certain node (sequence of child indices) and returns that node.