### PR TITLE
Changed sampling to enforce the max_depth constraint

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -10,25 +10,8 @@ Generates a random RuleNode of return type typ and maximum depth max_depth.
 """
 function Base.rand(::Type{RuleNode}, grammar::Grammar, typ::Symbol, max_depth::Int=10, 
     bin::Union{NodeRecycler,Nothing}=nothing)
-    rules = grammar[typ]
-    
-    if max_depth <= 1
-        terminals = filter(r->isterminal(grammar,r), rules)
-        rule_index = !isempty(terminals) ? StatsBase.sample(terminals) : StatsBase.sample(rules)
-    else    
-        rule_index = StatsBase.sample(rules)
-    end
-
-    rulenode = iseval(grammar, rule_index) ?
-        RuleNode(bin, rule_index, Core.eval(grammar, rule_index)) :
-        RuleNode(bin, rule_index)
-
-    if !grammar.isterminal[rule_index]
-        for ch in child_types(grammar, rule_index)
-            push!(rulenode.children, rand(RuleNode, grammar, ch, max_depth-1, bin))
-        end
-    end
-    return rulenode
+    dmap = mindepth_map(grammar)
+    return rand(RuleNode, grammar, typ, dmap, max_depth)
 end
 """
     rand(::Type{RuleNode}, grammar::Grammar, typ::Symbol, dmap::AbstractVector{Int}, max_depth::Int=10)
@@ -38,7 +21,14 @@ Generates a random RuleNode of return type typ and maximum depth max_depth guide
 function Base.rand(::Type{RuleNode}, grammar::Grammar, typ::Symbol, dmap::AbstractVector{Int}, 
     max_depth::Int=10, bin::Union{NodeRecycler,Nothing}=nothing)
     rules = grammar[typ]
-    rule_index = StatsBase.sample(filter(r->dmap[r] ≤ max_depth, rules))
+    filtered = filter(r->dmap[r] ≤ max_depth, rules)
+    if isempty(filtered)
+        error("The random function could not find an expression of the given $max_depth depth")
+        return
+    end
+
+    rule_index = StatsBase.sample(filtered)
+    @assert max_depth >= 0
 
     rulenode = iseval(grammar, rule_index) ?
         RuleNode(bin, rule_index, Core.eval(grammar, rule_index)) :

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,7 +7,7 @@ AbstractTrees.printnode(io::IO, node::RuleNode) = print(io, node.ind)
 Returns the minimum depth achievable for each production rule, dmap.
 """
 function mindepth_map(grammar::Grammar)
-    dmap0 = Int[isterminal(grammar,i) ? 0 : typemax(Int)/2 for i in eachindex(grammar.rules)]
+    dmap0 = Int[isterminal(grammar,i) ? 1 : typemax(Int)/2 for i in eachindex(grammar.rules)]
     dmap1 = fill(-1, length(grammar.rules)) 
     while dmap0 != dmap1
         for i in eachindex(grammar.rules)
@@ -20,7 +20,7 @@ end
 
 
 function _mindepth(grammar::Grammar, rule_index::Int, dmap::AbstractVector{Int})
-    isterminal(grammar, rule_index) && return 0
+    isterminal(grammar, rule_index) && return 1
     return 1 + maximum([mindepth(grammar, ctyp, dmap) for ctyp in child_types(grammar, rule_index)])
 end
 

--- a/test/test_cfg.jl
+++ b/test/test_cfg.jl
@@ -86,5 +86,60 @@
         rm("toy_pcfg.grammar")
     end
 
+    @testset "Sampling grammar" begin
 
+        @testset "Sampling tests return proper depth" begin
+            arithmetic_grammar = @cfgrammar begin
+                X = X * X
+                X = X + X
+                X = X - X
+                X = |(1:4)
+            end
+
+            for max_depth in 1:20
+                expression_generated = rand(RuleNode, arithmetic_grammar, :X, max_depth)
+                depth_generated = depth(expression_generated)
+                if depth(expression_generated) > max_depth
+                    println(depth_generated," ",max_depth)
+                end
+                @test depth(expression_generated) <= max_depth
+            end
+        end
+        @testset "Sampling gives the only expression for a certain depth" begin
+            grammar = @cfgrammar begin 
+                A = B | C | F
+                F = G
+                C = D
+                D = E
+            end
+            # A->B (depth 1) or A->F->G (depth 2) or A->C->D->E (depth 3)
+
+            # For depth ≤ 1 the only option is A->B
+            expression = rand(RuleNode, grammar, :A, 1)
+            @test depth(expression) == 1
+            @test expression == RuleNode(1)
+        end
+
+        @testset "Sampling throws an error if all expressions have a higher depth than max_depth" begin
+            grammar = @cfgrammar begin 
+                A = B 
+                B = C
+                C = D
+                D = E
+                E = F
+            end
+            # A->B->C->D->E->F (depth 5)
+            real_depth = 5
+            
+            # it does not work for max_depth < 5
+            for max_depth in 1:real_depth - 1
+                @test_throws ErrorException expression = rand(RuleNode, grammar, :A, max_depth)
+            end
+            
+            # it works for max_depth = 5
+            expression = rand(RuleNode, grammar, :A, real_depth)
+            @test depth(expression) == real_depth
+        end
+    end
+    
 end


### PR DESCRIPTION
Before the `max_depth` provided to the sampling function was not always taken into account.
This happened in the case where an unfortunate choice was made for a rule that would require more than `max_depth` to be fully expanded.

The fix was to use `mindepth_map` function for each rule and only sample from the rules that would make it possible to have a depth `<= max_depth`.