### PR TITLE
Remove Constraint export from HerbGrammar.jl 

### DIFF
--- a/src/HerbGrammar.jl
+++ b/src/HerbGrammar.jl
@@ -29,7 +29,6 @@ export
 
     ContextFreeGrammar,
 
-    Constraint,
     ContextSensitiveGrammar,
     AbstractRuleNode,
     RuleNode,


### PR DESCRIPTION
Remove Constraint export from HerbGrammar.jl since it got moved to HerbCore.jl