### PR TITLE
Fix empty grammar creation

### DIFF
--- a/src/csg/csg.jl
+++ b/src/csg/csg.jl
@@ -84,9 +84,9 @@ function expr2csgrammar(ex::Expr)::ContextSensitiveGrammar
 		end
 	end
 	alltypes = collect(keys(bytype))
-	is_terminal = [isterminal(rule, alltypes) for rule ∈ rules]
-	is_eval = [iseval(rule) for rule ∈ rules]
-	childtypes = [get_childtypes(rule, alltypes) for rule ∈ rules]
+	is_terminal::Vector{Bool} = [isterminal(rule, alltypes) for rule ∈ rules]
+	is_eval::Vector{Bool} = [iseval(rule) for rule ∈ rules]
+	childtypes::Vector{Vector{Symbol}} = [get_childtypes(rule, alltypes) for rule ∈ rules]
 	domains = Dict(type => BitArray(r ∈ bytype[type] for r ∈ 1:length(rules)) for type ∈ alltypes)
 	return ContextSensitiveGrammar(rules, types, is_terminal, is_eval, bytype, domains, childtypes, nothing)
 end

--- a/test/test_csg.jl
+++ b/test/test_csg.jl
@@ -8,7 +8,7 @@
         @test isempty(g.bytype)
         @test isempty(g.domains)
         @test isempty(g.childtypes)
-        @test isempty(g.log_probabilities)
+        @test isnothing(g.log_probabilities)
     end
 
     @testset "Creating grammars" begin

--- a/test/test_csg.jl
+++ b/test/test_csg.jl
@@ -1,4 +1,16 @@
 @testset verbose=true "CSGs" begin
+    @testset "Create empty grammar" begin
+        g = @csgrammar begin end
+        @test isempty(g.rules)
+        @test isempty(g.types)
+        @test isempty(g.isterminal)
+        @test isempty(g.iseval)
+        @test isempty(g.bytype)
+        @test isempty(g.domains)
+        @test isempty(g.childtypes)
+        @test isempty(g.log_probabilities)
+    end
+
     @testset "Creating grammars" begin
         g₁ = @cfgrammar begin
             Real = |(1:9)


### PR DESCRIPTION
We were just missing some type annotations to force `Vector`s to be more specific than `Vector{Any}`.

Closes #53.