### PR TITLE
Update versions for `DataStructures` to ensure compat with `SExpressions`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 
 [compat]
 AbstractTrees = "^0.4"
-DataStructures = "^0.18"
+DataStructures = "0.17,0.18"
 TreeView = "^0.5"
 HerbCore = "^0.2.0"
 julia = "^1.8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
`SExpressions`, extensively used in `HerbBenchmarks/SyGuS`, has dependency `DataStructures= "0.14,0.17"` resolving to `[0.14,0.19)`. 
Changed the `DataStructures` compat in `HerbGrammar` to `^0.18`, which passed all checks, but leads to this not being compatible anymore. 