### PR TITLE
Make `expr2csgrammar` use `add_rule!` internally

### DIFF
--- a/src/csg/csg.jl
+++ b/src/csg/csg.jl
@@ -48,6 +48,8 @@ ContextSensitiveGrammar(
 	log_probabilities::Union{Vector{<:Real}, Nothing}
 ) = ContextSensitiveGrammar(rules, types, isterminal, iseval, bytype, domains, childtypes, bychildtypes, log_probabilities, AbstractConstraint[])
 
+ContextSensitiveGrammar() = ContextSensitiveGrammar([], [], BitVector[], BitVector[], Dict{Symbol, Vector{Int}}(), Dict{Symbol, BitVector}(), Vector{Vector{Symbol}}(), Vector{BitVector}(), nothing, AbstractConstraint[])
+
 """
 	expr2csgrammar(ex::Expr)::ContextSensitiveGrammar
 
@@ -68,31 +70,15 @@ grammar = expr2csgrammar(
 ```
 """
 function expr2csgrammar(ex::Expr)::ContextSensitiveGrammar
-	rules = Any[]
-	types = Symbol[]
-	bytype = Dict{Symbol,Vector{Int}}()
+	grammar = ContextSensitiveGrammar()
+	
 	for e ∈ ex.args
 		if isa(e, Expr)
-			if e.head == :(=)
-				s = e.args[1] 		# name of return type
-				rule = e.args[2] 	# expression?
-				rvec = Any[]
-				parse_rule!(rvec, rule)
-				for r ∈ rvec
-					push!(rules, r)
-					push!(types, s)
-					bytype[s] = push!(get(bytype, s, Int[]), length(rules))
-				end
-			end
+			add_rule!(grammar, e)
 		end
 	end
-	alltypes = collect(keys(bytype))
-	is_terminal::Vector{Bool} = [isterminal(rule, alltypes) for rule ∈ rules]
-	is_eval::Vector{Bool} = [iseval(rule) for rule ∈ rules]
-	childtypes::Vector{Vector{Symbol}} = [get_childtypes(rule, alltypes) for rule ∈ rules]
-	domains = Dict(type => BitArray(r ∈ bytype[type] for r ∈ 1:length(rules)) for type ∈ alltypes)
-	bychildtypes = [BitVector([childtypes[i1] == childtypes[i2] for i2 ∈ 1:length(rules)]) for i1 ∈ 1:length(rules)]
-	return ContextSensitiveGrammar(rules, types, is_terminal, is_eval, bytype, domains, childtypes, bychildtypes, nothing)
+
+	return grammar
 end
 
 

--- a/test/test_csg.jl
+++ b/test/test_csg.jl
@@ -27,6 +27,11 @@
             Real = 1 | 2 | 3
         end
         @test g₃.rules == [1,2,3]
+
+        g₄ = @cfgrammar begin
+            Real = 1 | 1
+        end
+        @test g₄.rules == [1]
     end
 
 
@@ -38,6 +43,12 @@
         # Basic adding
         add_rule!(g₁, :(Real = 3))
         @test g₁.rules == [1, 2, 3]
+        @test g₁.bytype[:Real] == [1, 2, 3]
+        @test g₁.types == [:Real, :Real, :Real]
+        @test g₁.isterminal == [true, true, true]
+        @test g₁.iseval == [false, false, false]
+        @test g₁.childtypes == [[], [], []]
+        @test g₁.bychildtypes == [BitVector((1, 1, 1)) for _ in 1:3]
 
         # Adding multiple rules in one line
         add_rule!(g₁, :(Real = 4 | 5))


### PR DESCRIPTION
Currently, duplicate rules are ignored when using `add_rule!`:

https://github.com/Herb-AI/HerbGrammar.jl/blob/e3bc05c99b5678bdd79af054b0c990777cc839d9/test/test_csg.jl#L53-L59

However, they are not when using `@csgrammar`:


This PR makes the behavior of `@csgrammar` and `add_rule!` more similar (hopefully identical) by using `add_rule!` when constructing the grammar using the `@csgrammar` macro.

Mainly, I've added a test to show the unexpected behavior and updated `expr2csgrammar`.



