### PR TITLE
Bug/csgrammar macro returns object not expr

### DIFF
--- a/src/csg/csg.jl
+++ b/src/csg/csg.jl
@@ -116,7 +116,7 @@ end
 - [`@pcsgrammar`](@ref) uses a similar syntax to create probabilistic [`ContextSensitiveGrammar`](@ref)s.
 """
 macro csgrammar(ex)
-	return expr2csgrammar(ex)
+	return :(expr2csgrammar($(QuoteNode(ex))))
 end
 
 

--- a/src/csg/csg.jl
+++ b/src/csg/csg.jl
@@ -126,7 +126,7 @@ end
 This macro is deprecated and will be removed in future versions. Use [`@csgrammar`](@ref) instead.
 """
 macro cfgrammar(ex)
-	return expr2csgrammar(ex)
+	return :(expr2csgrammar($(QuoteNode(ex))))
 end
 
 parse_rule!(v::Vector{Any}, r) = push!(v, r)


### PR DESCRIPTION
Previously, the `@csgrammar` macro called `expr2csgrammar(...)` at macro expansion time instead of returning an expression that included a call to `expr2csgrammar(...)`. This made it impossible for debuggers to stop on breakpoints inside calls to the macro because those breakpoints were being hit at macro expansion time, not runtime.

The functionality is unchanged, but the debugging experience is improved, and the macro now follows a more Julian pattern for macros: simply taking an expression and returning an expression.
