### PR TITLE
Allow `insert!`ion of `AbstractRuleNode`s

### DIFF
--- a/src/nodelocation.jl
+++ b/src/nodelocation.jl
@@ -33,7 +33,7 @@ end
 insert!(loc::NodeLoc, rulenode::RuleNode)
 Replaces the subtree pointed to by loc with the given rulenode.
 """
-function Base.insert!(root::RuleNode, loc::NodeLoc, rulenode::RuleNode)
+function Base.insert!(root::RuleNode, loc::NodeLoc, rulenode::AbstractRuleNode)
     parent, i = loc.parent, loc.i
     if loc.i > 0
         parent.children[i] = rulenode


### PR DESCRIPTION
Currently, restricting to concrete `RuleNode`s restricts the user from inserting a `Hole`, for example.