### PR TITLE
[v0.2.x] Allow `insert!`ion of `AbstractRuleNode`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/nodelocation.jl
+++ b/src/nodelocation.jl
@@ -44,3 +44,22 @@ function Base.insert!(root::RuleNode, loc::NodeLoc, rulenode::RuleNode)
 	end
 	return root
 end
+
+"""
+insert!(root::RuleNode, loc::NodeLoc, hole::Hole)
+
+Inserts a hole at the location pointed to by loc.
+
+!!! warning
+The user is responsible for ensuring that the hole's domain matches the domain of
+the node it is replacing. This function does not currently check for this.
+"""
+function Base.insert!(root::RuleNode, loc::NodeLoc, hole::Hole)
+	parent, i = loc.parent, loc.i
+	if loc.i > 0
+		parent.children[i] = hole
+	else
+		throw(ArgumentError("Inserting a hole at the root node is not supported."))
+	end
+	return root
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,5 @@ using Test
 @testset "HerbGrammar.jl" verbose=true begin
     include("test_csg.jl")
     include("test_rulenode_operators.jl")
+    include("test_nodelocation.jl")
 end

--- a/test/test_nodelocation.jl
+++ b/test/test_nodelocation.jl
@@ -1,0 +1,32 @@
+using HerbCore
+
+
+@testset verbose = true "NodeLoc" begin
+
+    @testset "Replace root with a rulenode" begin
+        root = RuleNode(1, [
+            RuleNode(2, []),
+            RuleNode(3, [
+                RuleNode(4, [])
+            ])
+        ])
+        loc = NodeLoc(root, 0)
+        new_node = RuleNode(5, [])
+        insert!(root, loc, new_node)
+        @test get(root, loc) == new_node
+    end
+
+    @testset "Replace subtree with hole" begin
+        root = RuleNode(1, [
+            RuleNode(2, []),
+            RuleNode(3, [
+                RuleNode(4, [])
+            ])
+        ])
+        loc = NodeLoc(root, 2)
+        new_node = Hole([0, 0, 0, 1])
+        insert!(root, loc, new_node)
+        @test get(root, loc) isa Hole
+        @test get(root, loc).domain == [0, 0, 0, 1]
+    end
+end


### PR DESCRIPTION
Currently, restricting to concrete `RuleNode`s restricts the user from inserting a `Hole`, for example.