### PR TITLE
Remove line numbers in PCSG construction

### DIFF
--- a/src/csg/probabilistic_csg.jl
+++ b/src/csg/probabilistic_csg.jl
@@ -52,13 +52,14 @@ Returns `nothing` if the rule is not probabilistic, otherwise a `Tuple` of its t
 `Vector` of probability-rule pairs it expands into.
 """
 function parse_probabilistic_rule(e::Expr)
+	e = Base.remove_linenums!(e)
 	prvec = Tuple{Real, Any}[]
 	if e.head == :(=)
 		left = e.args[1]		# name of return type and probability
 		if left isa Expr && left.head == :call && left.args[1] == :(:)
 			p = left.args[2] 			# Probability
 			s = left.args[3]			# Return type
-			rule = e.args[2].args[2] 	# extract rule from block expr
+			rule = e.args[2].args[1] 	# extract rule from block expr
 
 			rvec = Any[]
 			parse_rule!(rvec, rule)

--- a/src/csg/probabilistic_csg.jl
+++ b/src/csg/probabilistic_csg.jl
@@ -138,9 +138,9 @@ The probabilities are automatically scaled if this isn't the case.
 - [`@csgrammar`](@ref) uses a similar syntax to create non-probabilistic [`ContextSensitiveGrammar`](@ref)s.
 """
 macro pcsgrammar(ex)
-	return expr2pcsgrammar(ex)
+	return :(expr2pcsgrammar($(QuoteNode(ex))))
 end
 
 macro pcfgrammar(ex)
-	return expr2pcsgrammar(ex)
+	return :(expr2pcsgrammar($(QuoteNode(ex))))
 end

--- a/test/test_csg.jl
+++ b/test/test_csg.jl
@@ -171,6 +171,20 @@
         @test sum(map(exp, g.log_probabilities[g.bytype[:R]])) ≈ 1.0
         @test sum(map(exp, g.log_probabilities[g.bytype[:B]])) ≈ 1.0
     end
+
+    @testset "Creating a non-probabilistic rule in a PCSG" begin
+        expected_log = (
+            :error,
+            "Rule without probability encountered in probabilistic grammar. Rule ignored."
+        )
+
+        @test_logs expected_log match_mode=:any begin
+            @pcsgrammar begin
+                0.5 : R = x
+                R = R + R
+            end
+        end
+    end
     
     @testset "Test that strict equality is used during rule creation" begin
         g₁ = @csgrammar begin

--- a/test/test_csg.jl
+++ b/test/test_csg.jl
@@ -227,4 +227,18 @@
         @test g.bychildtypes[8] == [0, 0, 0, 0, 0, 0, 1, 1] # 7, 8
     end
 
+    @testset "Check that macros return an expr, not an object" begin
+        @test typeof(@macroexpand @csgrammar begin 
+            A = 1
+        end) == Expr
+        @test typeof(@macroexpand @cfgrammar begin 
+            A = 1
+        end) == Expr
+        @test typeof(@macroexpand @pcsgrammar begin 
+            1.0 : A = 1
+        end) == Expr
+        @test typeof(@macroexpand @pcfgrammar begin 
+            1.0 : A = 1
+        end) == Expr
+    end
 end


### PR DESCRIPTION
While adding a test for this case of constructing a probabilistic CSG

https://github.com/Herb-AI/HerbGrammar.jl/blob/d3ff2322448651acac4625adfbafe7c22fcae3fa/src/csg/probabilistic_csg.jl#L71-L74

I ran into a `BoundsError`. It was only hit when using the `@pcsgrammar` macro within the `@test_logs` macro. This was because the `@test_logs` macro removes the line numbers of any input expression, while our implementation for `@pcsgrammar` relied on the existence of the line numbers.

<details><summary>Error</summary>
<p>

```julia
HerbGrammar.jl: Error During Test at HerbGrammar.jl/test/runtests.jl:5
  Got exception outside of a @test
  LoadError: BoundsError: attempt to access 1-element Vector{Any} at index [2]
  Stacktrace:
    [1] getindex(A::Vector{Any}, i1::Int64)
      @ Base ./essentials.jl:13
    [2] parse_probabilistic_rule(e::Expr)
      @ HerbGrammar HerbGrammar.jl/src/csg/probabilistic_csg.jl:72
    [3] expr2pcsgrammar(ex::Expr)
      @ HerbGrammar HerbGrammar.jl/src/csg/probabilistic_csg.jl:26
    [4] var"@pcsgrammar"(__source__::LineNumberNode, __module__::Module, ex::Any)
      @ HerbGrammar HerbGrammar.jl/src/csg/probabilistic_csg.jl:152
    [5] include(fname::String)
      @ Base.MainInclude ./client.jl:489
    [6] macro expansion
      @ HerbGrammar.jl/test/runtests.jl:6 [inlined]
    [7] macro expansion
      @ julia/stdlib/v1.10/Test/src/Test.jl:1577 [inlined]
    [8] top-level scope
      @ HerbGrammar.jl/test/runtests.jl:6
    [9] include(fname::String)
      @ Base.MainInclude ./client.jl:489
   [10] top-level scope
      @ none:6
   [11] eval
      @ ./boot.jl:385 [inlined]
   [12] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:291
   [13] _start()
      @ Base ./client.jl:552
  in expression starting at HerbGrammar.jl/test/test_csg.jl:182
  in expression starting at HerbGrammar.jl/test/test_csg.jl:1
Test Summary:  | Error  Total  Time
HerbGrammar.jl |     1      1  1.4s
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
in expression starting at HerbGrammar.jl/test/runtests.jl:5
ERROR: Package HerbGrammar errored during testing
```

</p>
</details> 

This fix removes the line numbers and fixes the faulty index that relied on the line numbers being present. It also makes the probabilistic macros return an `Expr`. This should have been included in #75, but I missed it before.