### PR TITLE
Fix skipping of new repeated rules

### DIFF
--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -214,7 +214,7 @@ function add_rule!(g::AbstractGrammar, e::Expr)
             # Only add a rule if it does not exist yet. Check for existance
             # with strict equality so that true and 1 are not considered
             # equal. that means we can't use `in` or `∈` for equality checking.
-            if !any(r === rule || typeof(r)==Expr && r == rule for rule ∈ g.rules)
+            if !any(s == type && (r === rule || typeof(r)==Expr && r == rule) for (type, rule) ∈ zip(g.types, g.rules))
                 push!(g.rules, r)
                 push!(g.iseval, iseval(rule))
                 push!(g.types, s)

--- a/test/test_csg.jl
+++ b/test/test_csg.jl
@@ -255,4 +255,24 @@
             1.0 : A = 1
         end) == Expr
     end
+
+    @testset "Test adding duplicated rules" begin
+        g = @cfgrammar begin
+            S = 1 + A
+            S = 2 * B
+            A = 1
+            B = 1
+            B = 2
+        end
+        # All rules should be present in grammar
+        @test g.rules == [:(1 + A), :(2 * B), 1, 1, 2]
+
+        # Adding duplicated rule
+        add_rule!(g, :(A = 1))
+        @test g.rules == [:(1 + A), :(2 * B), 1, 1, 2]
+ 
+        # Adding new rule with already existing rhs
+        add_rule!(g, :(A = 2))
+        @test g.rules == [:(1 + A), :(2 * B), 1, 1, 2, 2]
+    end 
 end


### PR DESCRIPTION
This PR add an extra check to ensure that the rule is skipped only if both lhs and rhs together are already present in the grammar.

Minimal example of a grammar affected by the change:
```julia
g = @cfgrammar begin
           S = 1 + A
           S = 2 * B
           A = 1
           B = 1
           B = 2
       end
```
Previously rule `B = 1` would be skipped.