### PR TITLE
Fix `expr2rulenode` for lone `Symbol`s and `Number`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/rulenode_operators.jl
+++ b/src/rulenode_operators.jl
@@ -354,7 +354,7 @@ end
 Converts an expression into a [`AbstractRuleNode`](@ref) corresponding to the rule definitions in the grammar.
 """
 function expr2rulenode(expr::Symbol, grammar::AbstractGrammar, startSymbol::Symbol)
-    tags = get_tags(grammar)
+    tags = grammar_map_right_to_left(grammar)
     (s, rn) = expr2rulenode(expr, grammar, tags)
     while s != startSymbol
             
@@ -375,9 +375,9 @@ end
 
 Converts an expression into a [`AbstractRuleNode`](@ref) corresponding to the rule definitions in the grammar.
 """
-function expr2rulenode(expr::Symbol, grammar::AbstractGrammar)
-    tags = get_tags(grammar)
-    (s, rn) = expr2rulenode(expr, grammar, tags)
+function expr2rulenode(expr::Union{Symbol,Number}, grammar::AbstractGrammar)
+    tags = grammar_map_right_to_left(grammar)
+    (s, rn) = _expr2rulenode(expr, grammar, tags)
     return rn
 end
 

--- a/test/test_expr2rulenode.jl
+++ b/test/test_expr2rulenode.jl
@@ -43,5 +43,27 @@
     @test expr2rulenode(expr5, g2) == RuleNode(12, [RuleNode(14, []), RuleNode(3, [RuleNode(4, [RuleNode(9, [])]) , RuleNode(2, [RuleNode(4, [RuleNode(6, [])])])]), RuleNode(2, [RuleNode(4, [RuleNode(6, [])])])])
     @test expr2rulenode(expr5, g2, :Start) == RuleNode(1, [RuleNode(2, [RuleNode(5, [RuleNode(12, [RuleNode(14, []), RuleNode(3, [RuleNode(4, [RuleNode(9, [])]) , RuleNode(2, [RuleNode(4, [RuleNode(6, [])])])]), RuleNode(2, [RuleNode(4, [RuleNode(6, [])])])])])])])
     
-end
+    int_grammar = @csgrammar begin
+        Val = 0 | 1 | 2
+    end
 
+    int_expr = :(2)
+    @test expr2rulenode(int_expr, int_grammar) == RuleNode(3)
+    @test rulenode2expr(expr2rulenode(int_expr, int_grammar), int_grammar) == int_expr
+
+    float_grammar = @csgrammar begin
+        Val = 0.0 | 1.0 | 2.0 | 3.14
+    end
+
+    float_expr = :(3.14)
+    @test expr2rulenode(float_expr, float_grammar) == RuleNode(4)
+    @test rulenode2expr(expr2rulenode(float_expr, float_grammar), float_grammar) == float_expr
+    
+    sym_grammar = @csgrammar begin
+        Val = x
+    end
+
+    sym = :(x)
+    @test expr2rulenode(sym, sym_grammar) == RuleNode(1)
+    @test rulenode2expr(expr2rulenode(sym, sym_grammar), sym_grammar) == sym
+end


### PR DESCRIPTION
Conversion is currently failing on expressions like `:(x)`, `:(2)`, and `:(3.14)`.

This PR addresses those cases.