### PR TITLE
[`v0.3.x`] Place upper limit on `HerbCore` compat for `HerbGrammar`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -13,7 +13,7 @@ TreeView = "39424ebd-4cf3-5550-a685-96706a953f40"
 [compat]
 AbstractTrees = "^0.4"
 DataStructures = "0.17,0.18"
-HerbCore = "^0.3.0"
+HerbCore = "0.3.0 - 0.3.2"
 TreeView = "^0.5"
 julia = "^1.8"
 


### PR DESCRIPTION
`HerbCore>0.3.2` includes methods that are in `HerbGrammar==0.3.x` but were moved to `HerbCore` because they were pirated and should have been defined there in the first place. However, including them in `HerbGrammar` causes precompilation errors since the methods are being overwritten. Placing an upper bound on the compat prevents the conflicting versions from being loaded together.

TLDR: `Herb@0.3` has many precompilation warnings and fails precompilation. This fixes the versions so that the offending methods are no longer overwritten and no longer cause precompilation to fail.

This includes a bump to `0.3.1` that we can release when merging this PR.