### PR TITLE
Update constraints in add_rule! and merge_grammars!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "0.5.3"
+version = "0.6.0"
 
 [deps]
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"

--- a/src/csg/csg.jl
+++ b/src/csg/csg.jl
@@ -24,31 +24,31 @@ Use the [`@csgrammar`](@ref) macro to create a [`ContextSensitiveGrammar`](@ref)
 Use the [`@pcsgrammar`](@ref) macro to create a [`ContextSensitiveGrammar`](@ref) object with probabilities.
 """
 mutable struct ContextSensitiveGrammar <: AbstractGrammar
-	rules::Vector{Any}
-	types::Vector{Union{Symbol, Nothing}}
-	isterminal::BitVector
-	iseval::BitVector
-	bytype::Dict{Symbol, Vector{Int}}
-	domains::Dict{Symbol,BitVector}    				
-	childtypes::Vector{Vector{Symbol}}
-	bychildtypes::Vector{BitVector}
-	log_probabilities::Union{Vector{Real}, Nothing}
-	constraints::Vector{AbstractConstraint}
+    rules::Vector{Any}
+    types::Vector{Union{Symbol,Nothing}}
+    isterminal::BitVector
+    iseval::BitVector
+    bytype::Dict{Symbol,Vector{Int}}
+    domains::Dict{Symbol,BitVector}
+    childtypes::Vector{Vector{Symbol}}
+    bychildtypes::Vector{BitVector}
+    log_probabilities::Union{Vector{Real},Nothing}
+    constraints::Vector{AbstractConstraint}
 end
 
 ContextSensitiveGrammar(
-	rules::Vector{<:Any},
-	types::Vector{<:Union{Symbol, Nothing}},
-	isterminal::Union{BitVector, Vector{Bool}},
-	iseval::Union{BitVector, Vector{Bool}},
-	bytype::Dict{Symbol, Vector{Int}},
-	domains::Dict{Symbol, BitVector},
-	childtypes::Vector{Vector{Symbol}},
-	bychildtypes::Vector{BitVector},
-	log_probabilities::Union{Vector{<:Real}, Nothing}
+    rules::Vector{<:Any},
+    types::Vector{<:Union{Symbol,Nothing}},
+    isterminal::Union{BitVector,Vector{Bool}},
+    iseval::Union{BitVector,Vector{Bool}},
+    bytype::Dict{Symbol,Vector{Int}},
+    domains::Dict{Symbol,BitVector},
+    childtypes::Vector{Vector{Symbol}},
+    bychildtypes::Vector{BitVector},
+    log_probabilities::Union{Vector{<:Real},Nothing}
 ) = ContextSensitiveGrammar(rules, types, isterminal, iseval, bytype, domains, childtypes, bychildtypes, log_probabilities, AbstractConstraint[])
 
-ContextSensitiveGrammar() = ContextSensitiveGrammar([], [], BitVector[], BitVector[], Dict{Symbol, Vector{Int}}(), Dict{Symbol, BitVector}(), Vector{Vector{Symbol}}(), Vector{BitVector}(), nothing, AbstractConstraint[])
+ContextSensitiveGrammar() = ContextSensitiveGrammar([], [], BitVector[], BitVector[], Dict{Symbol,Vector{Int}}(), Dict{Symbol,BitVector}(), Vector{Vector{Symbol}}(), Vector{BitVector}(), nothing, AbstractConstraint[])
 
 """
 	expr2csgrammar(ex::Expr)::ContextSensitiveGrammar
@@ -70,15 +70,15 @@ grammar = expr2csgrammar(
 ```
 """
 function expr2csgrammar(ex::Expr)::ContextSensitiveGrammar
-	grammar = ContextSensitiveGrammar()
-	
-	for e ∈ ex.args
-		if isa(e, Expr)
-			add_rule!(grammar, e)
-		end
-	end
+    grammar = ContextSensitiveGrammar()
 
-	return grammar
+    for e ∈ ex.args
+        if isa(e, Expr)
+            add_rule!(grammar, e)
+        end
+    end
+
+    return grammar
 end
 
 
@@ -116,7 +116,7 @@ end
 - [`@pcsgrammar`](@ref) uses a similar syntax to create probabilistic [`ContextSensitiveGrammar`](@ref)s.
 """
 macro csgrammar(ex)
-	return :(expr2csgrammar($(QuoteNode(ex))))
+    return :(expr2csgrammar($(QuoteNode(ex))))
 end
 
 
@@ -126,7 +126,7 @@ end
 This macro is deprecated and will be removed in future versions. Use [`@csgrammar`](@ref) instead.
 """
 macro cfgrammar(ex)
-	return :(expr2csgrammar($(QuoteNode(ex))))
+    return :(expr2csgrammar($(QuoteNode(ex))))
 end
 
 parse_rule!(v::Vector{Any}, r) = push!(v, r)
@@ -135,7 +135,7 @@ function parse_rule!(v::Vector{Any}, ex::Expr)
     # Strips `LineNumberNode`s from the expression
     Base.remove_linenums!(ex)
 
-    if ex.head == :call && ex.args[1] == :|	
+    if ex.head == :call && ex.args[1] == :|
         terms = _expand_shorthand(ex.args)
 
         for t in terms
@@ -147,26 +147,26 @@ function parse_rule!(v::Vector{Any}, ex::Expr)
 end
 
 function _expand_shorthand(args::Vector{Any})
-	# expand a rule using the `|` symbol:
-	# `X = |(1:3)`, `X = 1|2|3`, `X = |([1,2,3])`
-	# these should all be equivalent and should expand to
-	# the following 3 rules: `X = 1`, `X = 2`, and `X = 3`
-	if args[1] != :|
-		throw(ArgumentError("Tried to parse: $ex as a shorthand rule, but it is not a shorthand rule."))
-	end
+    # expand a rule using the `|` symbol:
+    # `X = |(1:3)`, `X = 1|2|3`, `X = |([1,2,3])`
+    # these should all be equivalent and should expand to
+    # the following 3 rules: `X = 1`, `X = 2`, and `X = 3`
+    if args[1] != :|
+        throw(ArgumentError("Tried to parse: $ex as a shorthand rule, but it is not a shorthand rule."))
+    end
 
-	if length(args) == 2
-		to_expand = args[2]
-		if to_expand.args[1] == :(:)
-			expanded = collect(to_expand.args[2]:to_expand.args[3])	# (1:3) case
-		else
-			expanded = to_expand.args								# ([1,2,3]) case
-		end
-	elseif length(args) == 3
-		expanded = args[2:end]										# 1|2|3 case
-	else
-		throw(ArgumentError("Failed to parse shorthand for rule: $ex"))
-	end
+    if length(args) == 2
+        to_expand = args[2]
+        if to_expand.args[1] == :(:)
+            expanded = collect(to_expand.args[2]:to_expand.args[3])# (1:3) case
+        else
+            expanded = to_expand.args# ([1,2,3]) case
+        end
+    elseif length(args) == 3
+        expanded = args[2:end]# 1|2|3 case
+    else
+        throw(ArgumentError("Failed to parse shorthand for rule: $ex"))
+    end
 end
 
 """
@@ -182,7 +182,7 @@ Clear all constraints from the grammar
 clearconstraints!(grammar::ContextSensitiveGrammar) = empty!(grammar.constraints)
 
 function Base.display(rulenode::RuleNode, grammar::ContextSensitiveGrammar)
-	return rulenode2expr(rulenode, grammar)
+    return rulenode2expr(rulenode, grammar)
 end
 
 """
@@ -191,11 +191,22 @@ end
 Adds all rules and constraints from `merge_from` to `merge_to`.
 """
 function merge_grammars!(merge_to::AbstractGrammar, merge_from::AbstractGrammar)
-	for i in eachindex(merge_from.rules)
-		expression = :($(merge_from.types[i]) = $(merge_from.rules[i]))
-		add_rule!(merge_to, expression)
-	end
-	for i in eachindex(merge_from.constraints)
-		addconstraint!(merge_to, merge_from.constraints[i])
-	end
+    mapping = Dict{Integer,Integer}() # keep track of new rule indices for merge_from grammar
+    # add rules
+    for i in eachindex(merge_from.rules)
+        n_rules_before = length(merge_to.rules)
+        expression = :($(merge_from.types[i]) = $(merge_from.rules[i]))
+        add_rule!(merge_to, expression)
+        # if rule was added, update mapping
+        n_rules_after = length(merge_to.rules)
+        if n_rules_before < n_rules_after
+            mapping[i] = n_rules_after
+        end
+    end
+    # update constraints
+    for c in merge_from.constraints
+        addconstraint!(merge_to, c)
+        HerbCore.update_rule_indices!(c, length(merge_to.rules), mapping, merge_to.constraints)
+
+    end
 end

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -156,15 +156,15 @@ The syntax is identical to the syntax of [`@csgrammar`](@ref) and [`@cfgrammar`]
 """
 function add_rule!(g::AbstractGrammar, e::Expr)
     if e.head == :(=) && typeof(e.args[1]) == Symbol
-        s = e.args[1]		# Name of return type
-        rule = e.args[2]	# expression?
+        s = e.args[1]# Name of return type
+        rule = e.args[2]# expression?
         rvec = Any[]
         parse_rule!(rvec, rule)
         for r ∈ rvec
             # Only add a rule if it does not exist yet. Check for existance
             # with strict equality so that true and 1 are not considered
             # equal. that means we can't use `in` or `∈` for equality checking.
-            if !any(s == type && (r === rule || typeof(r)==Expr && r == rule) for (type, rule) ∈ zip(g.types, g.rules))
+            if !any(s == type && (r === rule || typeof(r) == Expr && r == rule) for (type, rule) ∈ zip(g.types, g.rules))
                 push!(g.rules, r)
                 push!(g.iseval, iseval(rule))
                 push!(g.types, s)
@@ -182,6 +182,10 @@ function add_rule!(g::AbstractGrammar, e::Expr)
     g.childtypes = [get_childtypes(rule, alltypes) for rule ∈ g.rules]
     g.bychildtypes = [BitVector([g.childtypes[i1] == g.childtypes[i2] for i2 ∈ 1:length(g.rules)]) for i1 ∈ 1:length(g.rules)]
     g.domains = Dict(type => BitArray(r ∈ g.bytype[type] for r ∈ 1:length(g.rules)) for type ∈ keys(g.bytype))
+    # update grammar constraints
+    for c in g.constraints
+        HerbCore.update_rule_indices!(c, length(g.rules))
+    end
     return g
 end
 

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -143,7 +143,7 @@ max_arity(grammar::AbstractGrammar)::Int = maximum(length(cs) for cs in grammar.
 """
     add_rule!(g::AbstractGrammar, e::Expr)
 
-Adds a rule to the grammar. 
+Adds a rule to the grammar and updates grammar constraints as required. 
 
 ### Usage: 
 ```

--- a/test/test_csg.jl
+++ b/test/test_csg.jl
@@ -1,4 +1,4 @@
-@testset verbose=true "CSGs" begin
+@testset verbose = true "CSGs" begin
     @testset "Create empty grammar" begin
         g = @csgrammar begin end
         @test isempty(g.rules)
@@ -19,14 +19,14 @@
         @test :Real ∈ g₁.types
 
         g₂ = @cfgrammar begin
-            Real = |([1,2,3])
+            Real = |([1, 2, 3])
         end
-        @test g₂.rules == [1,2,3]
+        @test g₂.rules == [1, 2, 3]
 
         g₃ = @cfgrammar begin
             Real = 1 | 2 | 3
         end
-        @test g₃.rules == [1,2,3]
+        @test g₃.rules == [1, 2, 3]
 
         g₄ = @cfgrammar begin
             Real = 1 | 1
@@ -99,7 +99,7 @@
             Real = |(1:5)
             Real = 6 | 7 | 8
         end
-        
+
         store_csg(g₁, "toy_cfg.grammar")
         g₂ = read_csg("toy_cfg.grammar")
         @test :Real ∈ g₂.types
@@ -108,7 +108,7 @@
         # delete file afterwards
         rm("toy_cfg.grammar")
     end
-    
+
     @testset "Test that strict equality is used during rule creation" begin
         g₁ = @csgrammar begin
             R = x
@@ -117,7 +117,7 @@
 
         add_rule!(g₁, :(R = 1 | 2))
 
-        add_rule!(g₁,:(Bool = true))
+        add_rule!(g₁, :(Bool = true))
 
         @test all(g₁.rules .== [:x, :(R + R), 1, 2, true])
 
@@ -126,7 +126,7 @@
             R = R + R
         end
 
-        add_rule!(g₁,:(Bool = true))
+        add_rule!(g₁, :(Bool = true))
 
         add_rule!(g₁, :(R = 1 | 2))
 
@@ -144,7 +144,7 @@
             S = 7 + S
             A = 8 + S
         end
-        
+
         @test g.childtypes[1] == []
         @test g.childtypes[2] == [:S, :A]
         @test g.childtypes[3] == [:A, :S]
@@ -153,7 +153,7 @@
         @test g.childtypes[6] == [:S, :S]
         @test g.childtypes[7] == [:S]
         @test g.childtypes[8] == [:S]
-        
+
         @test g.bychildtypes[1] == [1, 0, 0, 1, 0, 0, 0, 0] # 1, 4
         @test g.bychildtypes[2] == [0, 1, 0, 0, 0, 0, 0, 0] # 2
         @test g.bychildtypes[3] == [0, 0, 1, 0, 0, 0, 0, 0] # 3
@@ -165,17 +165,17 @@
     end
 
     @testset "Check that macros return an expr, not an object" begin
-        @test typeof(@macroexpand @csgrammar begin 
+        @test typeof(@macroexpand @csgrammar begin
             A = 1
         end) == Expr
-        @test typeof(@macroexpand @cfgrammar begin 
+        @test typeof(@macroexpand @cfgrammar begin
             A = 1
         end) == Expr
-        @test typeof(@macroexpand @pcsgrammar begin 
-            1.0 : A = 1
+        @test typeof(@macroexpand @pcsgrammar begin
+            1.0:A = 1
         end) == Expr
-        @test typeof(@macroexpand @pcfgrammar begin 
-            1.0 : A = 1
+        @test typeof(@macroexpand @pcfgrammar begin
+            1.0:A = 1
         end) == Expr
     end
 
@@ -193,22 +193,22 @@
         # Adding duplicated rule
         add_rule!(g, :(A = 1))
         @test g.rules == [:(1 + A), :(2 * B), 1, 1, 2]
- 
+
         # Adding new rule with already existing rhs
         add_rule!(g, :(A = 2))
         @test g.rules == [:(1 + A), :(2 * B), 1, 1, 2, 2]
-    end 
+    end
 
-    @testset "Add tree to grammar" begin 
+    @testset "Add tree to grammar" begin
         g = @cfgrammar begin
             Number = |(1:2)
             Number = x
-            Number = Number + Number 
+            Number = Number + Number
             Number = Number * Number
         end
         hole = Hole(get_domain(g, g.bytype[:Number]))
         test_ast = RuleNode(4, [RuleNode(1), hole])
-        
+
         add_rule!(g, test_ast)
         @test g.rules[6] == :(1 + Number)
     end


### PR DESCRIPTION
Updates grammar constraints by calling `update_rule_indices!` on each constraint when
- adding a new grammar rule with `add_rule!`
- merging two grammars with `merge_grammars!`

Note: tests are in [this HerbConstraints PR](https://github.com/Herb-AI/HerbConstraints.jl/pull/93). 

See also #113 
