### PR TITLE
Define `return_type` for `RuleNode` and `UniformHole`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HerbGrammar"
 uuid = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 authors = ["Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Jaap de Jong <J.deJong-18@student.tudelft.nl>", "Nicolae Filat <N.Filat@student.tudelft.nl>", "Piotr Cichoń <gitlab@gitlab.ewi.tudelft.nl>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"

--- a/src/grammar_base.jl
+++ b/src/grammar_base.jl
@@ -61,6 +61,20 @@ Returns the type of the production rule at `rule_index`.
 """
 return_type(grammar::AbstractGrammar, rule_index::Int) = grammar.types[rule_index]
 
+"""
+    return_type(grammar::AbstractGrammar, rulenode::RuleNode)
+
+Get the type of the `rulenode` with respect to the `grammar`.
+"""
+return_type(grammar::AbstractGrammar, rulenode::RuleNode) = return_type(grammar, get_rule(rulenode))
+
+"""
+    return_type(grammar::AbstractGrammar, uniform_hole::UniformHole)
+
+Get the type of the `uniform_hole` with respect to the `grammar`.
+"""
+return_type(grammar::AbstractGrammar, uniform_hole::UniformHole) = return_type(grammar, findfirst(uniform_hole.domain))
+
 
 """
     child_types(grammar::AbstractGrammar, rule_index::Int)

--- a/test/test_csg.jl
+++ b/test/test_csg.jl
@@ -212,4 +212,16 @@
         add_rule!(g, test_ast)
         @test g.rules[6] == :(1 + Number)
     end
+
+    @testset "Get return type of a node/rule" begin
+        g = @csgrammar begin
+            Int = 1
+            String = "A"
+        end
+
+        @test return_type(g, 1) == :Int
+        @test return_type(g, @rulenode 1) == :Int
+        @test return_type(g, @rulenode 2) == :String
+        @test return_type(g, @rulenode UniformHole[0, 1]) == :String
+    end
 end


### PR DESCRIPTION
Towards addressing https://github.com/Herb-AI/HerbCore.jl/issues/50

We already have `return_type`, so no need to introduce `get_type` as I had suggested in https://github.com/Herb-AI/HerbCore.jl/issues/50.

It's super useful to have these defined, because otherwise you're constantly checking whether an `AbstractRulenode` is a `RuleNode` or a `UniformHole` and then doing slightly different calculations to access the type from the grammar. To avoid duplicating this logic/code, we can just add these new methods to `return_type`. 🥳 